### PR TITLE
Fix for running all Python scripts (except benchmark.py)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ go:
 
 # Python
 python:
-	python3 src/python/compress_*.py
+	find src/python -type f \( -iname "*.py" ! -iname benchmarks.py \) | xargs -n1 python
 
 # JavaScript
 javascript:


### PR DESCRIPTION
This is the fix for [issue 33](https://github.com/otobrglez/compression-puzzle/issues/33) reported by @refaktor.