### PR TITLE
Compress with regex match into chunks

### DIFF
--- a/src/javascript/compress_lpg.js
+++ b/src/javascript/compress_lpg.js
@@ -1,0 +1,3 @@
+const compress = (s) => s.match(/(.)\1*/g).map(x => `${x.length}${x[0]}`).join('');
+
+require("assert").equal(compress("AAABBAAC"), "3A2B2A1C");


### PR DESCRIPTION
Splits the string into chunks of same character, then maps them into compressed form and joins back together