### PR TITLE
python, short, reduce examples

### DIFF
--- a/src/python/compress_ew.py
+++ b/src/python/compress_ew.py
@@ -1,0 +1,12 @@
+def compress(s='', r="", c=1):
+    for p, v in zip(s, s[1:] + '0'):
+        if p == v:
+            c += 1
+        else:
+            r += str(c) + p
+            c = 1
+
+    return r
+
+
+assert compress("AAABBAAC") == "3A2B2A1C"

--- a/src/python/compress_ew2.py
+++ b/src/python/compress_ew2.py
@@ -1,0 +1,7 @@
+def compress(s='', r='', c=1):
+    for p, v in zip(s, s[1:] + '0'):
+        [r,c]=([r+str(c)+p,1],[r,c+1])[p==v]
+    return r
+
+
+assert compress("AAABBAAC") == "3A2B2A1C"

--- a/src/python/compress_ew3.py
+++ b/src/python/compress_ew3.py
@@ -1,0 +1,5 @@
+from functools import reduce
+
+compress=lambda s:reduce(lambda a,b:([a[0]+str(a[1])+b,1,a[2]+1],[a[0],a[1]+1,a[2]+1])[a[2]+1<len(s)and b==s[a[2]+1]],s,['',1,0])[0]
+
+assert compress("AAABBAAC") == "3A2B2A1C"

--- a/src/python/compress_ew4.py
+++ b/src/python/compress_ew4.py
@@ -1,0 +1,5 @@
+from functools import reduce
+
+compress=lambda s:reduce(lambda a,b:([a[0]+str(a[1])+b[0],1],[a[0],a[1]+1])[b[0]==b[1]],zip(s,s[1:]+'0'),['',1])[0]
+
+assert compress("AAABBAAC") == "3A2B2A1C"


### PR DESCRIPTION
I've tried my luck golfing also in python :)

in 108 bytes:
`s=lambda s:reduce(lambda a,b:([a[0]+str(a[1])+b[0],1],[a[0],a[1]+1])[b[0]==b[1]],zip(s,s[1:]+'0'),['',1])[0]`